### PR TITLE
Add my name and GitHub profile

### DIFF
--- a/assets/contributors.js
+++ b/assets/contributors.js
@@ -7,4 +7,8 @@ export const contributors = [
     name: 'cuHacking Example',
     githubProfile: 'https://github.com/cuHacking'
   }
+   {
+    name: 'Josh Cadieux',
+    githubProfile: 'https://github.com/JCadoo2002'
+  }
 ]


### PR DESCRIPTION
Part of the 2020 GitHub workshop. Excuse the typo on the title, I meant to type "add-name" not "add-anme"